### PR TITLE
Add xdBot and Eclipse Menu to "bots that use GDR"

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ These extensions can be accessed the same way you access regular fields
  - [iCreate Pro](https://icreate.pro) by camila314
  - [Prism Menu](https://github.com/FireMario211/Prism-Menu) by Firee
  - [xdBot](https://github.com/ZiLko/xdBot) by ZiLko
- - [Eclipse Menu](https://github.com/EclipseMenu/EclipseMenu) by ninXout, prevter, maxnut, Firee and SpaghettDev
+ - [Eclipse Menu](https://github.com/EclipseMenu/EclipseMenu) by Eclipse Team (ninXout, prevter, maxnut, Firee and SpaghettDev)
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ These extensions can be accessed the same way you access regular fields
  - [iCreate Pro](https://icreate.pro) by camila314
  - [Prism Menu](https://github.com/FireMario211/Prism-Menu) by Firee
  - [xdBot](https://github.com/ZiLko/xdBot) by ZiLko
+ - [Eclipse Menu] by ninXout, prevter, maxnut, Firee and SpaghettDev
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ These extensions can be accessed the same way you access regular fields
  - [iCreate Pro](https://icreate.pro) by camila314
  - [Prism Menu](https://github.com/FireMario211/Prism-Menu) by Firee
  - [xdBot](https://github.com/ZiLko/xdBot) by ZiLko
- - [Eclipse Menu] by ninXout, prevter, maxnut, Firee and SpaghettDev
+ - [Eclipse Menu](https://github.com/EclipseMenu/EclipseMenu) by ninXout, prevter, maxnut, Firee and SpaghettDev
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ These extensions can be accessed the same way you access regular fields
  - [Crystal Client v5](https://github.com/ninXout/Crystal-Client) by ninXout
  - [iCreate Pro](https://icreate.pro) by camila314
  - [Prism Menu](https://github.com/FireMario211/Prism-Menu) by Firee
+ - [xdBot](https://github.com/ZiLko/xdBot) by ZiLko
 
 ## Credits
 


### PR DESCRIPTION
The 2.0.0 rewrite in xdBot now uses GDR. And Eclipse Menu has a bot that uses GDR as well, which is why I made this pull request!